### PR TITLE
Make original banner data available in template

### DIFF
--- a/src/Resources/contao/classes/BannerTemplate.php
+++ b/src/Resources/contao/classes/BannerTemplate.php
@@ -57,6 +57,7 @@ class BannerTemplate
             case 18: // WEBP
                 $arrBanners[] =
                 [
+                'banner'         => $objBanners->row(),
                 'banner_key'     => 'bid',
                 'banner_wrap_id'    => $banner_cssID,
                 'banner_wrap_class' => $banner_class,
@@ -79,6 +80,7 @@ class BannerTemplate
             default:
                 $arrBanners[] =
                 [
+                'banner'         => $objBanners->row(),
                 'banner_key'     => 'bid',
                 'banner_wrap_id'    => $banner_cssID,
                 'banner_wrap_class' => $banner_class,


### PR DESCRIPTION
Currently a banner's original data is not available in the `mod_banner_*` template. This PR would make this data available under the `banner` array key. This would be useful in case you want to render banners in a specific module with a specific image size via `$this->figure()` for example.